### PR TITLE
add a maintenance page

### DIFF
--- a/src/collective/generic/skel/buildout/plone/tmpl/etc/templates/www/apache.reverseproxy.conf.in_tmpl
+++ b/src/collective/generic/skel/buildout/plone/tmpl/etc/templates/www/apache.reverseproxy.conf.in_tmpl
@@ -23,6 +23,11 @@ RewriteEngine  on
 ProxyPass         /zmiroot/ http://\${hosts:zope-front}:\${ports:zope-front}/VirtualHostBase/\${scheme}/\${host}:\${port}/VirtualHostRoot/_vh_zmiroot/ retry=1
 ProxyPassReverse  /zmiroot/ http://\${hosts:zope-front}:\${ports:zope-front}/VirtualHostBase/\${scheme}/\${host}:\${port}/VirtualHostRoot/_vh_zmiroot/
 
+## maintenance page
+RewriteCond ${buildout:directory}/etc/www/maintenance.html -f
+RewriteCond %{REQUEST_URI} !/etc/www/maintenance.html
+RewriteRule $ /etc/www/maintenance.html [R=302,L]
+
 #if $with_supervisor
 # supervisor
 ProxyPass         /supervisor/ http://\${hosts:supervisor}:\${ports:supervisor}/ retry=1

--- a/src/collective/generic/skel/buildout/plone/tmpl/etc/templates/www/maintenance_disabled.html
+++ b/src/collective/generic/skel/buildout/plone/tmpl/etc/templates/www/maintenance_disabled.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html PUBLIC
+  "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr"
+      lang="fr">
+<head>
+    <meta http-equiv="Content-Type"
+          content="text/html;charset=utf-8" />
+<title>Maintenance</title>
+</head>
+<body>
+<p>
+Sorry, this website is currently down for maintenance.
+</p>
+</body>
+</html>


### PR DESCRIPTION
By renaming maintenance_disabled.html into maintenance.html, the site is closed and displays a maintenance page.
